### PR TITLE
Fix KeyError in response

### DIFF
--- a/src/py2neo/neo4j.py
+++ b/src/py2neo/neo4j.py
@@ -98,7 +98,7 @@ class Batch(object):
         ]))
         return [
             rest.Response(
-                self.graph_db, response["status"], response["from"],
+                self.graph_db, rs.status, response["from"],
                 response.get("location", None), response.get("body", None),
             )
             for response in rs.body


### PR DESCRIPTION
Adding a node to an index was erroring as there is no such key 'status'.
