### PR TITLE
SystemError doesnt take keyword arguments

### DIFF
--- a/src/py2neo/rest.py
+++ b/src/py2neo/rest.py
@@ -272,7 +272,7 @@ class Response(object):
         elif self.status == 409:
             raise ResourceConflict(uri, id_=id)
         elif self.status // 100 == 5:
-            raise SystemError(body, id=id)
+            raise SystemError(body)
 
 
 class Client(object):


### PR DESCRIPTION
```
  File "py2neo/cypher.py", line 261, in execute
    params, row_handler=row_handler, metadata_handler=metadata_handler, error_handler=error_handler
  File "py2neo/cypher.py", line 101, in execute
    rest.Request(self.graph_db, "POST", self.graph_db._cypher_uri, _payload(self.query, params))
  File "py2neo/rest.py", line 413, in _send
    return self._client().send(request)
  File "py2neo/rest.py", line 353, in send
    return Response(request.graph_db, rs.status, request.uri, rs.getheader("Location", None), rs_body)
  File "py2neo/rest.py", line 278, in __init__
    raise SystemError(body, id=id)
TypeError: exceptions.SystemError does not take keyword arguments
```

The line numbers maybe slightly off in that trace as it's from another branch which I have some extra debug in. I believe this issue still exists in master though.
