### PR TITLE
`UnicodeDecodeError` when querying index with non-Latin characters

### DIFF
--- a/src/py2neo/util.py
+++ b/src/py2neo/util.py
@@ -43,7 +43,7 @@ def quote(string, safe='/'):
     """ Quote a string for use in URIs.
     """
     try:
-        return _quote(string, safe)
+        return _quote(string, safe.encode("utf-8"))
     except UnicodeEncodeError:
         return string
 

--- a/test/py2neo/index_test.py
+++ b/test/py2neo/index_test.py
@@ -161,6 +161,16 @@ class NodeIndexTestCase(unittest.TestCase):
         self.assertTrue(green in colours_containing_R)
         self.assertFalse(blue in colours_containing_R)
 
+    def test_node_index_query_utf8(self):
+        red, green, blue = self.graph_db.create({}, {}, {})
+        self.index.add("colour", u"красный", red)
+        self.index.add("colour", u"зеленый", green)
+        self.index.add("colour", u"синий", blue)
+        colours_containing_R = self.index.query("colour:*ный*")
+        self.assertTrue(red in colours_containing_R)
+        self.assertTrue(green in colours_containing_R)
+        self.assertFalse(blue in colours_containing_R)
+
 
 class RemovalTests(unittest.TestCase):
 


### PR DESCRIPTION
Example (using cyrillic characters in `utf-8`):

``` python
index.query('string:*ряж*')
```

causes an `UnicodeDecodeError` error:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd1 in position 8: ordinal not in range(128)
```

A test for this patch added to the file `index_test.py`.
