### PR TITLE
Labels needs unicode support.

### DIFF
--- a/py2neo/neo4j.py
+++ b/py2neo/neo4j.py
@@ -1696,7 +1696,7 @@ class Node(_Entity):
 
         :param labels: one or more text labels
         """
-        labels = [str(label) for label in set(flatten(labels))]
+        labels = [unicode(label) for label in set(flatten(labels))]
         self._label_resource()._post(labels)
 
     def remove_labels(self, *labels):
@@ -1704,7 +1704,7 @@ class Node(_Entity):
 
         :param labels: one or more text labels
         """
-        labels = [str(label) for label in set(flatten(labels))]
+        labels = [unicode(label) for label in set(flatten(labels))]
         batch = WriteBatch(self.graph_db)
         for label in labels:
             batch.remove_label(self, label)
@@ -1715,7 +1715,7 @@ class Node(_Entity):
 
         :param labels: one or more text labels
         """
-        labels = [str(label) for label in set(flatten(labels))]
+        labels = [unicode(label) for label in set(flatten(labels))]
         self._label_resource()._put(labels)
 
 


### PR DESCRIPTION
Trying to set a list if labels where labels are,
labels = ['inventory_item', u'FSÖ', 'BAS']
caused:

```
Traceback (most recent call last):
  File "/home/lundberg/projects/deladryck/scripts/importer.py", line 62, in <module>
    item.set_labels(*labels)
  File "/home/lundberg/projects/deladryck/env/local/lib/python2.7/site-packages/py2neo/neo4j.py", line 1718, in set_labels
    labels = [str(label) for label in set(flatten(labels))]
UnicodeEncodeError: 'ascii' codec can't encode character u'\xd6' in position 2: ordinal not in range(128)
```

Using unicode instead of str fixes this.
