### PR TITLE
Neotools Shell Improvements

### DIFF
--- a/py2neo/tool.py
+++ b/py2neo/tool.py
@@ -547,7 +547,6 @@ class Shell(object):
                 writer.write(self.format, record_set)
 
     def execute_cypher_from_file(self, line):
-        #import pdb; pdb.set_trace()
         command, file_name = self._pop_command_and_filename(line)
         
         if not file_name:


### PR DESCRIPTION
Shell commands would fail and exit the repl if no argument to a command was provided.  
