### PR TITLE
Fixes KeyError when calling get_indexed_property_keys call

### DIFF
--- a/py2neo/neo4j.py
+++ b/py2neo/neo4j.py
@@ -1246,7 +1246,7 @@ class Schema(Cacheable, Resource):
                 raise
         else:
             return [
-                indexed["property-keys"][0]
+                indexed["property_keys"][0]
                 for indexed in response.json
             ]
 


### PR DESCRIPTION
The key being checked in the response was wrong, causing a KeyError.
