### PR TITLE
Support lists (or collections) for Node's name property

### DIFF
--- a/py2neo/types.py
+++ b/py2neo/types.py
@@ -715,7 +715,12 @@ class Entity(PropertyDict, Walkable):
         if "__name__" in properties:
             self.__name__ = properties["__name__"]
         elif "name" in properties:
-            self.__name__ = snake_case(properties["name"])
+            name = properties["name"]
+            if is_collection(name):
+                self.__name__ = snake_case("_".join(name))
+            else:
+                self.__name__ = snake_case(name)
+
         else:
             self.__name__ = self.__uuid__[-7:]
 

--- a/py2neo/util.py
+++ b/py2neo/util.py
@@ -33,6 +33,9 @@ WORD_ALL = re.compile("([a-z0-9])([A-Z])")
 
 
 def snake_case(s):
+    if is_collection(s):
+        s = "_".join(s)
+
     words = s.replace("_", " ").replace("-", " ").split()
     return "_".join(word.lower() for word in words)
 

--- a/py2neo/util.py
+++ b/py2neo/util.py
@@ -33,9 +33,6 @@ WORD_ALL = re.compile("([a-z0-9])([A-Z])")
 
 
 def snake_case(s):
-    if is_collection(s):
-        s = "_".join(s)
-
     words = s.replace("_", " ").replace("-", " ").split()
     return "_".join(word.lower() for word in words)
 

--- a/test/test_entity.py
+++ b/test/test_entity.py
@@ -21,7 +21,7 @@ from test.util import GraphTestCase
 
 
 class EntityTestCase(GraphTestCase):
-        
+
     def test_can_create_entity_with_initial_uri(self):
         uri = "http://localhost:7474/db/data/node/1"
         entity = Node()
@@ -69,6 +69,14 @@ class AutoNamingTestCase(GraphTestCase):
     def test_can_name_using_name_property(self):
         a = Node(name="Alice")
         assert a.__name__ == "alice"
+
+    def test_can_name_using_list_as_name_property(self):
+        a = Node(name=["Alice", "爱丽丝"])
+        assert a.__name__ == "alice_爱丽丝"
+
+    def test_can_name_using_tuple_as_name_property(self):
+        a = Node(name=("Alice", "爱丽丝"))
+        assert a.__name__ == "alice_爱丽丝"
 
     def test_can_name_using_magic_name_property(self):
         a = Node(__name__="Alice")


### PR DESCRIPTION
A person may have more than one name. For instance an English and a Chinese name. As such a person, represented as a Node type may have name property represented as a list. Implemented functionality to ensure lists, tuples and sets are supported for Node's name property. Some unit testing to cover this functionality.

p.s. There's a PR previously just before author announced the project won't be maintained