### PR TITLE
Do not install the geoff command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ package_metadata = {
         "console_scripts": [
             "py2neo = py2neo.__init__:main",
             "neokit = neokit:main",
-            "geoff = py2neo.ext.geoff.__main__:main",
         ],
     },
     "packages": packages,


### PR DESCRIPTION
The geoff extension was removed in commit 3cd59da, but the geoff command is still installed. When run it prints an error:

`ImportError: No module named geoff.__main__`

If the geoff extension will not come back then I suggest that the geoff command should no longer be installed.