### PR TITLE
Updated GraphObject with a kwargs-based constructor

### DIFF
--- a/py2neo/ogm.py
+++ b/py2neo/ogm.py
@@ -303,6 +303,16 @@ class GraphObject(object):
 
     __ogm = None
 
+    # Little hack to be able to construct new instances of classes inheriting Graphobject
+    # using keyword arguments. I.e. doing myNewClass(property1='value1',property2='value2')
+    # instead of myNewClass.property1 = 'value1', myNewClass.property2 = 'value2'.
+    def __init__(self, **kwargs):
+        for kwarg, value in kwargs.items():
+            if hasattr(self,kwarg):
+                self.__setattr__(kwarg, value)
+            else:
+                raise ValueError('Object %s does not have attr: %s' %(self.__class__, kwarg))
+
     def __eq__(self, other):
         if not isinstance(other, GraphObject):
             return False

--- a/test/test_ogm.py
+++ b/test/test_ogm.py
@@ -277,6 +277,17 @@ class CreateTestCase(MovieGraphTestCase):
         remote_node = remote(node)
         assert remote_node
 
+    def test_create_with_kwargs(self):
+        alice = Person(name="Alice", year_of_birth=1970)
+        alice.acted_in.add(Film.select(self.graph, "The Matrix").first())
+
+        alice2 = Person()
+        alice2.name = "Alice"
+        alice2.year_of_birth = 1970
+        alice2.acted_in.add(Film.select(self.graph, "The Matrix").first())
+
+        assert alice == alice2
+
     def test_create_has_no_effect_on_existing(self):
         # given
         keanu = Person.select(self.graph, "Keanu Reeves").first()


### PR DESCRIPTION
I found it useful to implement a silly constructor in GraphObject class so that instances of classes inheriting from GraphObject could be created in a more pythonic way. For example, given the class:
```python
class Student(GraphObject):
    __primarykey__ = "id"

    name = Property()
    id = Property()
    lastname = Property()
    english_level = Property()
    gender = Property()

    classes = RelatedTo("Class","ATTENDS")
```
Instead of doing:
```python
my_student = Student()
my_student.name = "John"
my_student.id = 1234
my_student.gender = "Male"
```
You could instead do:
```python
my_student = Student(name="John", id=1234, gender="Male")
```
Which I believe would be a more pythonic way of instantiating Student()

I also included a simple assertion test. 

I hope this could lead to an improvement in the library.