### PR TITLE
autodetect bolt

### DIFF
--- a/py2neo/database/auth.py
+++ b/py2neo/database/auth.py
@@ -37,6 +37,7 @@ class ServerAddress(object):
             uri_object = URI(u)
             if uri_object.scheme == "bolt":
                 self.__settings.setdefault("bolt_port", 7687)
+                self.__settings.setdefault("bolt", True)
             if uri_object.scheme == "https":
                 self.__settings["secure"] = True
             if uri_object.host:


### PR DESCRIPTION
When users use `Graph(uri, user=user, password=password)` to create a Graph connection, auto detect if uri is bolt schema.

Before this commit, bolt is False if users does not explictly declare `bolt=True`.
After this commit, it detects if the schema is bolt schema.