### PR TITLE
fix documentation for Graph.match()

### DIFF
--- a/py2neo/database.py
+++ b/py2neo/database.py
@@ -418,7 +418,7 @@ class Graph(object):
         For example, to find all of Alice's friends::
 
             for rel in graph.match(start_node=alice, rel_type="FRIEND"):
-                print(rel.end_node()["name"])
+                print(rel.end_node["name"])
 
         :param start_node: start node of relationships to match (:const:`None` means any node)
         :param rel_type: type of relationships to match (:const:`None` means any type)


### PR DESCRIPTION
It seems the documentation is wrong about the object returned by Graph.match() :

```
>>> for i in g.match(end_node=None, rel_type="FOLLOWS"):
...     print(i.start_node()['account'])
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
TypeError: 'Node' object is not callable
```

although

```
>>> for i in g.match(end_node=None, rel_type="FOLLOWS"):
...     print(i.start_node['account'])
... 
toto
titi
tata
...
```

rel.end_node seems to be a member, not a function. I'm quite new to Py2neo, sorry if I'm mistaken.

Best Regards,
Carl