### PR TITLE
pass uri down to subclass constructor

### DIFF
--- a/py2neo/data.py
+++ b/py2neo/data.py
@@ -147,7 +147,7 @@ class Graph(object):
 
         graph = find_subclass(cls, connection_data["scheme"])
         if graph:
-            return graph(uri=None, **settings)
+            return graph(uri=connection_data["uri"], **settings)
         else:
             raise NotImplementedError("Unsupported URI scheme %r" % connection_data["scheme"])
 


### PR DESCRIPTION
Currently, when specifying a remote uri in `Graph('bolt://some.remote.host:7687, ...)` the uri is ignored and the connection is attempted to `127.0.0.1` instead.

Take the uri and pass it to subclass instead of hardcoded `None`.