### PR TITLE
Conditional operator suffixes for property names when matching

### DIFF
--- a/docs/matching.rst
+++ b/docs/matching.rst
@@ -27,7 +27,7 @@ Many types of comparisons can be made with operator suffixes. By appending the o
         +--------------------------+--------------+-------------+------------------------------------------------------------+
         | Description              | Suffix       | Operator    | Example                                                    |
         +--------------------------+--------------+-------------+------------------------------------------------------------+
-        | Explicit Equal           | __exact      | =           | >>>matcher.match("Person", name__exact="Kevin Bacon")         |
+        | Explicit Equal           | __exact      | =           | matcher.match("Person", name__exact="Kevin Bacon")         |
         |                          |              |             | MATCH (_:Person) WHERE name = "Kevin Bacon" RETURN _       |
         +--------------------------+--------------+-------------+------------------------------------------------------------+
         | Not Equal                | __not        | <>          | matcher.match("Person", name__not="Rick Astley")           |

--- a/docs/matching.rst
+++ b/docs/matching.rst
@@ -22,6 +22,39 @@ For a simple match by label and property::
         >>> matcher.match("Person", name="Keanu Reeves").first()
         (_224:Person {born:1964,name:"Keanu Reeves"})
 
+Many types of comparisons can be made with operator suffixes. By appending the opeartor suffix you change the operator used in Cypher expression.
+
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Description              | Suffix       | Operator    | Example                                                    |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Explicit Equal           | __exact      | =           | >>>matcher.match("Person", name__exact="Kevin Bacon")         |
+        |                          |              |             | MATCH (_:Person) WHERE name = "Kevin Bacon" RETURN _       |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Not Equal                | __not        | <>          | matcher.match("Person", name__not="Rick Astley")           |
+        |                          |              |             | MATCH (_:Person) WHERE _.name <> "Rick Astley" RETURN _    |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Greater than             | __gt         | >           | matcher.match("Person", born__gt=1985)                     |
+        |                          |              |             | MATCH (_:Person) WHERE _.born > 1985 RETURN _              |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Greater than or equal to | __gte        | >=          | matcher.match("Person", born__gte=1965)                    |
+        |                          |              |             | MATCH (_:Person) WHERE _.born >= 1965 RETURN _             |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Less than                | __lt         | <           | matcher.match("Person", born__lt=1965)                     |
+        |                          |              |             | MATCH (_:Person) WHERE _.born < 1965 RETURN _              |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Less than or equal to    | __lte        | <=          | matcher.match("Person", born__lte=1965)                    |
+        |                          |              |             | MATCH (_:Person) WHERE _.born <= 1965 RETURN _             |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Starts with              | __startswith | STARTS WITH | matcher.match("Person", name__startswith="Kevin")          |
+        |                          |              |             | MATCH (_:Person) WHERE _.name STARTS WITH "Kevin" RETURN _ |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Ends with                | __endswith   | ENDS WITH   | matcher.match("Person", name__endswith="Smith")            |
+        |                          |              |             | MATCH (_:Person) WHERE _.name ENDS WITH "Smith" RETURN _   |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+        | Contains                 | __contains   | CONTAINS    | matcher.match("Person", name__contains="James")            |
+        |                          |              |             | MATCH (_:Person) HWERE _.name CONTAINS "James" RETURN _    |
+        +--------------------------+--------------+-------------+------------------------------------------------------------+
+
 For a more comprehensive match using Cypher expressions, the :meth:`.NodeMatch.where` method can be used to further refine the selection.
 Here, the underscore character can be used to refer to the node being filtered::
 

--- a/test/integration/test_matching.py
+++ b/test/integration/test_matching.py
@@ -118,6 +118,13 @@ class NodeMatcherTestCase(IntegrationTestCase):
         for actor in found:
             assert actor["born"] == year
 
+    def test_special_parameters_not(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__not=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] != year
+
     def test_special_parameters_regex(self):
         found = list(self.matcher.match("Person", name__regex='K.*'))
         found_names = {actor["name"] for actor in found}

--- a/test/integration/test_matching.py
+++ b/test/integration/test_matching.py
@@ -86,42 +86,42 @@ class NodeMatcherTestCase(IntegrationTestCase):
     def test_special_parameters_gt(self):
         year = 1985
         found = list(self.matcher.match("Person", born__gt=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] > year
 
     def test_special_parameters_gte(self):
         year = 1985
         found = list(self.matcher.match("Person", born__gte=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] >= year
 
     def test_special_parameters_lt(self):
         year = 1985
         found = list(self.matcher.match("Person", born__lt=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] < year
 
     def test_special_parameters_lte(self):
         year = 1985
         found = list(self.matcher.match("Person", born__lte=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] <= year
 
     def test_special_parameters_exact(self):
         year = 1985
         found = list(self.matcher.match("Person", born__exact=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] == year
 
     def test_special_parameters_not(self):
         year = 1985
         found = list(self.matcher.match("Person", born__not=year))
-        assert len(found) >= 1
+        assert found
         for actor in found:
             assert actor["born"] != year
 

--- a/test/integration/test_matching.py
+++ b/test/integration/test_matching.py
@@ -83,6 +83,62 @@ class NodeMatcherTestCase(IntegrationTestCase):
         assert first["name"] == "Keanu Reeves"
         assert first["born"] == 1964
 
+    def test_special_parameters_gt(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__gt=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] > year
+
+    def test_special_parameters_gte(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__gte=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] >= year
+
+    def test_special_parameters_lt(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__lt=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] < year
+
+    def test_special_parameters_lte(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__lte=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] <= year
+
+    def test_special_parameters_exact(self):
+        year = 1985
+        found = list(self.matcher.match("Person", born__exact=year))
+        assert len(found) >= 1
+        for actor in found:
+            assert actor["born"] == year
+
+    def test_special_parameters_regex(self):
+        found = list(self.matcher.match("Person", name__regex='K.*'))
+        found_names = {actor["name"] for actor in found}
+        assert found_names == {'Keanu Reeves', 'Kelly McGillis', 'Kevin Bacon',
+                               'Kevin Pollak', 'Kiefer Sutherland', 'Kelly Preston'}
+
+    def test_special_parameters_startswith(self):
+        found = list(self.matcher.match("Person", name__startswith='K'))
+        for actor in found:
+            assert actor["name"].startswith("K")
+
+    def test_special_parameters_endswith(self):
+        found = list(self.matcher.match("Person", name__endswith='eeves'))
+        for actor in found:
+            assert actor["name"].endswith("eeves")
+
+    def test_special_parameters_contains(self):
+        found = list(self.matcher.match("Person", name__contains='shall'))
+        for actor in found:
+            assert "shall" in actor["name"]
+
     def test_order_by(self):
         found = list(self.matcher.match("Person").where("_.name =~ 'K.*'").order_by("_.name"))
         found_names = [actor["name"] for actor in found]


### PR DESCRIPTION
Hello!

I'm just beginning to familiarize myself with graph databases and I was looking for a module that lets me interact with it more "Pythonically." py2neo looks great!

This pull request enables additional property comparisons by appending operators to arguments in the match statements. This is found in other ORMs and I thought it'd be neat in py2neo :-)

```
# Find people born after 1985
graph.match("Person").where("born > 1985")
graph.match("Person").where(("born > {1}", {"1": 1985}))
graph.match("Person", born__gt=1985)  # Pull request adds this
```

Operators include:
`__gt`: Greater than
`__gte`: Greater than or equal to
`__lt`: Less than
`__lte`: Less than or equal to
`__exact`: Explicit equals (`=`)
`__not`: Not equal to (`<>`)
`__startswith` and `__endswith`: Starts or ends with (`STARTS WITH` or `ENDS WITH`)
`__contains`: Contains operator (`CONTAINS`)