### PR TITLE
Make install on windows possible.

### DIFF
--- a/py2neo/internal/compat.py
+++ b/py2neo/internal/compat.py
@@ -42,7 +42,7 @@ try:
     from subprocess import DEVNULL
 except ImportError:
     from os import devnull
-    DEVNULL = open(devnull, "rw")
+    DEVNULL = open(devnull, "r+")
 
 from io import StringIO
 import os


### PR DESCRIPTION
Could not install on windows. I know you do not officially support it but before this change I got this error

```
Traceback (most recent call last):
  File "setup.py", line 25, in <module>
    from py2neo.meta import __author__, __email__, __license__, __package__, __version__
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\__init__.py", line 19, in <module>
    from py2neo.data import *
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\data.py", line 26, in <module>
    from py2neo.cypher import cypher_repr, cypher_str
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\cypher\__init__.py", line 25, in <module>
    from py2neo.cypher.encoding import CypherEncoder
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\cypher\encoding.py", line 30, in <module>
    from py2neo.internal.collections import SetView
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\internal\collections.py", line 24, in <module>
    from py2neo.internal.compat import bytes_types, string_types
  File "C:\Users\Mikae\Git\Chorus\neo\py2neo\py2neo\internal\compat.py", line 45, in <module>
    DEVNULL = open(devnull, "rw")
ValueError: Invalid mode ('rw')
```

Found this [here](https://stackoverflow.com/questions/51941916/pip-install-py2neo-failing)
