### PR TITLE
Relax prompt-toolkit requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==7.0
 colorama
 neobolt~=1.7.16
 neotime~=1.7.4
-prompt_toolkit~=2.0.7
+prompt_toolkit>=2.0.7,<4.0.0
 pygments~=2.3.1
 pytz
 urllib3<1.25,>=1.23

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ package_metadata = {
         "colorama",
         "neobolt~=1.7.12",
         "neotime~=1.7.4",
-        "prompt_toolkit~=2.0.7",
+        "prompt_toolkit>=2.0.7,<4.0.0",
         "pygments~=2.3.1",
         "pytz",
         "urllib3<1.25,>=1.23",


### PR DESCRIPTION
This PR relaxes the hard `prompt-toolkit~=2.0.7` requirement to `>=2.0.7,<4.0.0`, allowing py2neo to be installed in a wider range of environments.

I develop for a project that uses py2neo solely as a library, never touching `py2neo console`. I want to pin a version of prompt-toolkit in that project, so some dev niceties can be added to ipython. py2neo was super stringent on its prompt-toolkit version, so I've opened this PR.

The tests all pass on my machine. (Though, I had to fiddle with `where-is-java.sh` to accept `java-8-oracle`, too.) The console seems to perform well, with syntax highlighting still working.

Cheers!