### PR TITLE
Use chain.from_iterable in data.py

### DIFF
--- a/py2neo/data.py
+++ b/py2neo/data.py
@@ -671,7 +671,7 @@ class Subgraph(object):
     def keys(self):
         """ Set of all property keys.
         """
-        return frozenset(chain(chain(self.__nodes, self.__relationships)))
+        return frozenset(chain.from_iterable(chain(self.__nodes, self.__relationships)))
 
 
 class Walkable(Subgraph):

--- a/py2neo/data.py
+++ b/py2neo/data.py
@@ -566,7 +566,7 @@ class Subgraph(object):
     def __init__(self, nodes=None, relationships=None):
         self.__nodes = frozenset(nodes or [])
         self.__relationships = frozenset(relationships or [])
-        self.__nodes |= frozenset(chain(*(r.nodes for r in self.__relationships)))
+        self.__nodes |= frozenset(chain.from_iterable(r.nodes for r in self.__relationships))
         if not self.__nodes:
             raise ValueError("Subgraphs must contain at least one node")
 
@@ -661,7 +661,7 @@ class Subgraph(object):
     def labels(self):
         """ Set of all node labels.
         """
-        return frozenset(chain(*(node.labels for node in self.__nodes)))
+        return frozenset(chain.from_iterable(node.labels for node in self.__nodes))
 
     def types(self):
         """ Set of all relationship types.
@@ -671,8 +671,7 @@ class Subgraph(object):
     def keys(self):
         """ Set of all property keys.
         """
-        return (frozenset(chain(*(node.keys() for node in self.__nodes))) |
-                frozenset(chain(*(rel.keys() for rel in self.__relationships))))
+        return frozenset(chain(chain(self.__nodes, self.__relationships)))
 
 
 class Walkable(Subgraph):


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.