### PR TITLE
Prevent KeyError on broken connection

### DIFF
--- a/py2neo/client/__init__.py
+++ b/py2neo/client/__init__.py
@@ -876,7 +876,8 @@ class Connector(object):
                           "default database" if graph_name is None else repr(graph_name))
                 routing_table.remove(profile)
         log.debug("Pruning idle connections to %r", profile)
-        self._pools[profile].prune()
+        if profile in self._pools:
+            self._pools[profile].prune()
 
     def begin(self, graph_name, readonly=False,
               # after=None, metadata=None, timeout=None


### PR DESCRIPTION
This PR is fixing an error which occurs when the connection to the server is broken. Without this fix the error is:

```
...
    self._on_broken(self._profile, message)
  File "/tmp/neo4j/lib/python3.8/site-packages/py2neo/client/__init__.py", line 880, in _on_broken
    self._pools[profile].prune()
KeyError: ConnectionProfile('bolt://neo4j@neo4j-core.local:7687')
```

with the fix, the error gives the desired information what's going on:

```
...
  File "/tmp/neo4j/lib/python3.8/site-packages/py2neo/client/bolt.py", line 216, in open
    raise_from(ConnectionUnavailable("Cannot open connection to %r" % profile), error)
  File "<string>", line 3, in raise_from
py2neo.client.ConnectionUnavailable: Cannot open connection to ConnectionProfile('bolt://neo4j@neo4j-core.local:7687')
```