### PR TITLE
loosen prompt_toolkit version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ monotonic
 neotime~=1.7.4
 packaging
 pansi>=2020.7.3
-prompt_toolkit~=2.0.7
+prompt_toolkit>=2.0.7
 pygments>=2.0.0
 pytz
 six>=1.15.0


### PR DESCRIPTION
the strict version requirement is causing problems with other modules i need in a project