### PR TITLE
Added __ior__ method to Subgraph class to merge subgraphs more efficiently

### DIFF
--- a/py2neo/data/__init__.py
+++ b/py2neo/data/__init__.py
@@ -136,9 +136,9 @@ class Subgraph(object):
 
     def __ior__(self, other):
         if isinstance(self, Walkable):
-            self = Subgraph(self.nodes, self.relationships)
-        self.__nodes |= other.nodes
-        self.__relationships |= other.relationships
+            self = Subgraph(self.__nodes, self.__relationships)
+        self.__nodes |= other.__nodes
+        self.__relationships |= other.__relationships
         return self
 
     def __and__(self, other):

--- a/py2neo/data/__init__.py
+++ b/py2neo/data/__init__.py
@@ -134,6 +134,13 @@ class Subgraph(object):
     def __or__(self, other):
         return Subgraph(set(self.nodes) | set(other.nodes), set(self.relationships) | set(other.relationships))
 
+    def __ior__(self, other):
+        if isinstance(self, Walkable):
+            self = Subgraph(self.nodes, self.relationships)
+        self.__nodes |= other.nodes
+        self.__relationships |= other.relationships
+        return self
+
     def __and__(self, other):
         return Subgraph(set(self.nodes) & set(other.nodes), set(self.relationships) & set(other.relationships))
 


### PR DESCRIPTION
Right now union of subgraphs cannot be done in place, and the `|=` operator uses the `__or__` method. 
Added a `__ior__` method to the Subgraph class to make the `|=` operator more efficient.